### PR TITLE
productize to run as remote server

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/python-311
+FROM registry.redhat.io/ubi9/python-311:9.6
 
 WORKDIR /app
 
@@ -7,4 +7,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY ocm_mcp_server.py ./
 
-CMD ["python", "ocm_mcp_server.py"] 
+CMD ["python", "ocm_mcp_server.py"]

--- a/README.md
+++ b/README.md
@@ -20,12 +20,33 @@ Example configuration for running with Podman:
         "-e", "ACCESS_TOKEN_URL",
         "-e", "OCM_CLIENT_ID",
         "-e", "OCM_OFFLINE_TOKEN",
-        "quay.io/maorfr/ocm-mcp"
+        "-e", "MCP_TRANSPORT",
+        "quay.io/redhat-ai-tools/ocm-mcp"
       ],
       "env": {
         "ACCESS_TOKEN_URL": "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token",
         "OCM_CLIENT_ID": "cloud-services",
-        "OCM_OFFLINE_TOKEN": "REDACTED"
+        "OCM_OFFLINE_TOKEN": "REDACTED",
+        "MCP_TRANSPORT": "stdio"
+      }
+    }
+  }
+}
+```
+
+## Running with non-stdio transport
+
+To run the server with a non-stdio transport (such as SSE), set the `MCP_TRANSPORT` environment variable to a value other than `stdio` (e.g., `sse`).
+
+Example configuration to connect to a non-stdio MCP server:
+
+```json
+{
+  "mcpServers": {
+    "slack": {
+      "url": "https://ocm-mcp.example.com/sse",
+      "headers": {
+        "X-OCM-Offline-Token": "REDACTED"
       }
     }
   }

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -1,0 +1,114 @@
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: ocm-mcp
+parameters:
+  - name: IMAGE
+    value: quay.io/redhat-ai-tools/ocm-mcp
+  - name: IMAGE_TAG
+    value: latest
+  - name: MCP_TRANSPORT
+    value: sse
+  - name: FASTMCP_HOST
+    value: "0.0.0.0"
+  - name: CERT_MANAGER_ISSUER_NAME
+    value: letsencrypt-dns
+  - name: MCP_HOST
+    value: ocm-mcp.example.com
+  - name: OCM_CLIENT_ID
+    value: cloud-services
+  - name: ACCESS_TOKEN_URL
+    value: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+  - name: OCM_API_BASE
+    value: https://api.openshift.com
+objects:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: ocm-mcp
+    name: ocm-mcp
+  spec:
+    progressDeadlineSeconds: 600
+    replicas: 1
+    revisionHistoryLimit: 10
+    selector:
+      matchLabels:
+        app: ocm-mcp
+    strategy:
+      rollingUpdate:
+        maxSurge: 25%
+        maxUnavailable: 25%
+      type: RollingUpdate
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          app: ocm-mcp
+      spec:
+        containers:
+        - name: ocm-mcp
+          image: ${IMAGE}:${IMAGE_TAG}
+          imagePullPolicy: Always
+          env:
+          - name: MCP_TRANSPORT
+            value: ${MCP_TRANSPORT}
+          - name: FASTMCP_HOST
+            value: ${FASTMCP_HOST}
+          - name: OCM_CLIENT_ID
+            value: ${OCM_CLIENT_ID}
+          - name: ACCESS_TOKEN_URL
+            value: ${ACCESS_TOKEN_URL}
+          - name: OCM_API_BASE
+            value: ${OCM_API_BASE}
+          ports:
+          - containerPort: 8000
+            protocol: TCP
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        schedulerName: default-scheduler
+        securityContext: {}
+        terminationGracePeriodSeconds: 30
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: ocm-mcp
+    labels:
+      app: ocm-mcp
+  spec:
+    selector:
+      app: ocm-mcp
+    ports:
+      - protocol: TCP
+        port: 8000
+        targetPort: 8000
+    type: ClusterIP
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    annotations:
+      cert-manager.io/issuer-kind: ClusterIssuer
+      cert-manager.io/issuer-name: ${CERT_MANAGER_ISSUER_NAME}
+    name: ocm-mcp
+    labels:
+      app: ocm-mcp
+  spec:
+    host: ${MCP_HOST}
+    to:
+      kind: Service
+      name: ocm-mcp
+    port:
+      targetPort: 8000
+    tls:
+      insecureEdgeTerminationPolicy: Redirect
+      termination: edge

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-httpx
-fastmcp
+httpx==0.28.1
+fastmcp==2.8.0


### PR DESCRIPTION
part of https://issues.redhat.com/browse/RHOAIENG-27509

changes:
- support running in SSE and getting offline token from request headers
- pin dependencies to versions
- update docs
- add openshift template
- remove prints